### PR TITLE
add rs-station forum link

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,8 @@ on synchrotron and free electron sources.</p>
 <h2>Contact<a class="headerlink" href="#contact" title="Link to this heading">¶</a></h2>
 <p>For feature requests, bug reports or any other information, please contact
 the DIALS developers at <a class="reference external" href="mailto:dials-user-group&#37;&#52;&#48;jiscmail&#46;net">dials-user-group<span>&#64;</span>jiscmail<span>&#46;</span>net</a>, or post an
-<a class="reference external" href="https://github.com/dials/dials/issues">issue</a>.</p>
+<a class="reference external" href="https://github.com/dials/dials/issues">issue</a>. Ask developers and users for help on the 
+<a class="reference external" href="https://discourse.rs-station.org/c/software/dials/10">RS-Station Forum</a>.</p>
 </section>
 <section id="citing-dials">
 <h2>Citing DIALS<a class="headerlink" href="#citing-dials" title="Link to this heading">¶</a></h2>
@@ -128,6 +129,7 @@ facilities in using DIALS to analyse their diffraction data.
 <li class="toctree-l1"><a class="reference internal" href="documentation/tutorials/index.html">Tutorials</a></li>
 <li class="toctree-l1"><a class="reference internal" href="howto.html">How-to</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://dials.github.io/kb">Knowledge Base</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://discourse.rs-station.org/c/software/dials/10">Forum</a></li>
 <li class="toctree-l1"><a class="reference internal" href="workshops/index.html">Workshops</a></li>
 <li class="toctree-l1"><a class="reference internal" href="national_resource.html">US National Resource</a></li>
 <li class="toctree-l1"><a class="reference internal" href="publications.html">Publications</a></li>


### PR DESCRIPTION
The DIALS Category on the RS-Station forum could serve as a persistent, findable place for users to ask for help from other users and the DIALS developers. Users can log in with ORCID or GitHub and are able to post anonymously if they choose. The forum supports rich media and markdown formatting. Many of the DIALS developers already have accounts on RS-Station and have moderation privileges to manage the category.  

In this PR, I added a link to the DIALS forum category to the Contact section of `index.html` and to the sidebar mimicking the pattern used for the Knowledge Base. 